### PR TITLE
Add basic field-read-permission 'readFields'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Please note that this module does not automatically install `mongoose`.
   
   security.buildPolicy('MyModel').
     read({someProperty: 'someValue'}).
+    // only fields with final 'false' value are removed (or excluded) from select, query and ordering
+    readFields({someProperty: false, otherField: false}).
     update(function(parameters) {
       // some complicated logic...
       if (satisfied) {

--- a/index.js
+++ b/index.js
@@ -69,14 +69,93 @@ Security.prototype.init = function() {
         if (self.securityManager.isPrivileged()) {
             return next();
         } else {
-            self.policy.getCondition(query.model.modelName, 'read').then(function(condition) {
-                query.where(condition);
-                return next();
+            self.policy.getCondition(query.model.modelName, 'readFields').then(function(fields) {
+                if (fields) {
+                    applyFieldReadPermissions(query, fields);
+                }
+
+                // add read conditions after adding field security - otherwise read permissions could get
+                // modified (ignored) because of field security
+                self.policy.getCondition(query.model.modelName, 'read').then(function(condition) {
+                    query.where(condition);
+                    return next();
+                }).catch(function(error) {
+                    next(error);
+                });
             }).catch(function(error) {
                 next(error);
             });
         }
     });
+};
+
+var applyFieldReadPermissions = function(query, fields) {
+    var includesDefined = hasIncludedFieldsDefined(query);
+
+    _.forOwn(fields, function(readAllowed, fieldName) {
+        if (readAllowed) {
+            return;
+        }
+        applySelection(query, includesDefined, fieldName);
+        cleanSort(query.options, fieldName);
+        cleanQuery(query._conditions, fieldName);
+    });
+};
+
+var hasIncludedFieldsDefined = function(query) {
+    var includesDefined = false;
+    if (query._fields) {
+        _.forOwn(query._fields, function(value) {
+            if (value) {
+                includesDefined = true;
+            }
+        });
+    }
+    return includesDefined;
+};
+
+var applySelection = function(query, includesDefined, fieldName) {
+    if (includesDefined) { // we cannot mix excludes and includes, so only remove includes when existing
+        delete query._fields[fieldName];
+        if (_.isEmpty(query._fields)) { // in case no field is selected more, select id so that no other fields are exposed which are probably protected
+            query.select('_id');
+        }
+    } else {
+        query.select('-' + fieldName); // 'populate' is handled here also
+    }
+};
+
+var cleanSort = function(options, fieldName) {
+    if (options && options.sort) {
+        if (options.sort[fieldName]) {
+            delete options.sort[fieldName];
+        }
+    }
+};
+
+var cleanQuery = function(conditions, fieldName) {
+    if (conditions) {
+        var cleanQueryRecursively = function(conditions) {
+            _.forOwn(conditions, function(conditionValue, conditionKey) {
+                if (conditionKey === fieldName) {
+                    delete conditions[conditionKey];
+                }
+                if (conditionValue instanceof Array) {
+                    var hasNonEmptyValue = false;
+                    _.forEach(conditionValue, function(arrayItem) {
+                        cleanQueryRecursively(arrayItem);
+                        if (!_.isEmpty(arrayItem)) {
+                            hasNonEmptyValue = true;
+                        }
+                    });
+                    if (!hasNonEmptyValue) { // remove empty arrays (like '{'$or': []}')
+                        delete conditions[conditionKey];
+                    }
+                }
+            });
+        };
+        cleanQueryRecursively(conditions);
+    }
 };
 
 /**

--- a/lib/fielddomain.js
+++ b/lib/fielddomain.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var _ = require('lodash');
+
+var permissions = ['readFields'];
+
+/**
+ * Domain handling permission requests on field level
+ * @param {SecurityManager} securityManager
+ * @constructor
+ */
+function FieldDomain(securityManager) {
+    this.securityManager = securityManager;
+}
+
+FieldDomain.prototype.accept = function(permission) {
+    return _.contains(permissions, permission);
+};
+
+FieldDomain.prototype.getModelName = function(target) {
+    if (_.isString(target)) {
+        return target;
+    } else {
+        return target.constructor.modelName;
+    }
+};
+
+FieldDomain.prototype.aggregateConditions = function(conditions) {
+    var result = {};
+    _.forEach(conditions, function(condition) {
+        _.assign(result, condition);
+    });
+
+    return result;
+};
+
+module.exports = FieldDomain;

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -5,7 +5,8 @@ var _ = require('lodash'),
     promise = require('promise'),
     conditionBuilder = require('./conditionbuilder'),
     modelDomain = require('./modeldomain'),
-    documentDomain = require('./documentdomain');
+    documentDomain = require('./documentdomain'),
+    fieldDomain = require('./fielddomain');
 
 var getDomain = function(domains, target, permission) {
     var domain = _.find(domains, function(domain) {
@@ -18,11 +19,12 @@ var getDomain = function(domains, target, permission) {
 };
 
 function Policy(modelProviders, securityManager) {
-    this.permissions = ['create', 'read', 'update', 'remove'];
+    this.permissions = ['create', 'read', 'update', 'remove', 'readFields'];
     this.policy = {};
     this.modelProviders = modelProviders;
     this.securityManager = securityManager;
     this.domains = [
+        new fieldDomain(securityManager),
         new documentDomain(securityManager),
         new modelDomain()
     ];

--- a/package.json
+++ b/package.json
@@ -17,22 +17,22 @@
   "license": "MIT",
   "dependencies": {
     "hooks": "0.3.2",
-    "lodash": "3.3.1",
+    "lodash": "3.5.0",
     "promise": "6.1.0"
   },
   "devDependencies": {
     "coveralls": "2.11.2",
     "grunt-mocha-test": "0.12.7",
     "gulp": "3.8.11",
-    "gulp-jshint": "1.9.2",
+    "gulp-jshint": "1.9.4",
     "gulp-mocha": "2.0.0",
-    "istanbul": "0.3.6",
+    "istanbul": "0.3.8",
     "jshint-stylish": "1.0.1",
-    "mocha": "2.1.0",
+    "mocha": "2.2.1",
     "mockgoose": "1.10.7",
-    "mongoose": "3.8.24",
-    "proxyquire": "1.3.1",
-    "should": "5.0.1"
+    "mongoose": "3.8.25",
+    "proxyquire": "1.4.0",
+    "should": "5.2.0"
   },
   "bugs": {
     "url": "https://github.com/forrert/mongoose-model-security/issues/new"


### PR DESCRIPTION
- only fields with final 'false' value are removed (or excluded)
  from select, query and sort
- when trying to access / use fields without permission, fields are
  removed / ignored (but no unauthorized-exception is thrown)
